### PR TITLE
ENG-1285: Create release/goss-windows-amd64 rule and setup travis deploy rule with new key.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ go:
 go_import_path: github.com/aelsabbahy/goss
 
 sudo: required
-
 dist: trusty
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,27 +6,34 @@ go:
 go_import_path: github.com/aelsabbahy/goss
 
 sudo: required
+
+os:
+- linux
+- windows
+
 dist: trusty
 
 services:
 - docker
 
 before_install:
+- if [ "$TRAVIS_OS_NAME" == "windows" ]; then choco install make; fi
 - go get -u golang.org/x/lint/golint
 
 script:
-- make
+# TODO(stefan): windows does not currently support test-int-*.
+- if [ "$TRAVIS_OS_NAME" == "windows" ]; then make lint test; else make; fi
 
 deploy:
   provider: releases
   api_key:
-    secure: hEHCC4EN7iHz7pIWKRn2qw22NTqUxnuBp59wfAlLBtV26j5rHMzSu8mlxkJInusDUGLJiNLrZPRWN0mzOdIXalbUeLhlX7EflJgEj6Q0MchUR69LzCAp0KMIFL1Sfq0v81VgujRLUUy5utxDL8Er4tZknn2PpXAMzpO+ozjNRDhhSEM4iMXfY3bcOIMnx6XRgCjFCb036wlBgOfdgv5fwm2PP638DTKar4W6ZZbqCQByhJ5RyL3BMDPTT0moA/tYbG+FA6p6Rme1OcBkMnpsiJZoB3u8gxsNiEJ43/C2RcULW/18qqp2UVD5FipSDYP7GQ5ugKCbgpWXb0Ctl8o4hv1UsNl0XoyJhAt0PRp6vqnyy6LWB2FzX30Xj/vGIhO/IfiJvspHxpatTk7Esjr46K4u9ao/x63LX6F6yI1ZTfbzt2MhRYRjwh4ORNfqhysuzXChftX1S9hj6s6gO0/zqoOsRK/PK8DProbUn4bxrGOBzi16P0GEk4agWWUm74Pis9qCThXNW8MXEV936KvE1wb1RxTACYvFBtO2IM5eQ26t2Y7mGJd7FJup9LR4oUtUTSbYo5P2Sal6xntBKH5P4nwEtM+TtHoeSCKQ3X5i1VSdvAH7soEAly6rP5d5wwPhqqx9mgUPYO/3ulvxLJOYHamrbj6nlHDXnCEoj1ZMxX4=
+    secure: fjSvruBkLiuIXxCyomXRAcXjz6i+/sQiNWMrVjq2lICvs8OTXiYnOPtQZDsps8rfZTb4weDUQP8hJjd2IQKefMJuqRi4xcm976PhqFn/hjBJngOvHCrReHrfjuV5McGZlmxxittcvxBNj94hCRcQPL0CM7VFH11Jd/tmavQcpkLqjASwVWEozQjQlXRzWwbHCLt+xy1q/5Ql9+FvNAscQNqsgguUMUpa9D07ofMWBc/0UwEQsSeWOc+KujRXga+bjJvJ+Bg/s0jW9fUSwIwS9u7ib8f46mAZzz+Qwvz1qx5KOzUCUjhBqPz+e5b9i9hRvNHpnaK7wSlpbIurff4/8B6qGTQ/UP0+N0fYgx0vvIhQs976scGglsf2u3Mt3IYUnyG7m9kp28kjBXv3bKJZGGuqec/p37xkUIuNwA7dQepeNB2/d0VZE5M0IgItLHuv4pZNwp6jNVHzLN5lFXiLVpjLqRQYNR1cu9V1ImeKWuHg+sgop4CboBNrzp0hKRiUysqp31EU24s9RxzUZSbXF8lk1dLhLCjzuy0qkjPgGZudkUhXU+d6pZEkIP3Li5mWHJrcRaHSXrPMFfH7JHLHjkEJTRnh4kHdD3u7eAv+B5qIEp9mEweQEBXonjmoZp4jj0MKLrE6j6j/hIJC/HS1omscMQwauAliOGyHtSZTgAw=
   file:
     - release/goss-linux-amd64
     - release/goss-linux-386
     - release/goss-linux-arm
+    - release/goss-windows-amd64
     - extras/dgoss/dgoss
-  skip_cleanup: true
   on:
-    repo: aelsabbahy/goss
+    repo: improbable-eng/goss
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ go_import_path: github.com/aelsabbahy/goss
 
 sudo: required
 
-os:
-- linux
-- windows
-
 dist: trusty
 
 os:

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ release/goss-linux-amd64: $(GO_FILES)
 release/goss-linux-arm: $(GO_FILES)
 	$(info INFO: Starting build $@)
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -ldflags "-X main.version=$(TRAVIS_TAG) -s -w" -o release/$(cmd)-linux-arm $(exe)
+release/goss-windows-amd64: $(GO_FILES)
+	$(info INFO: Starting build $@)
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-X main.version=$(TRAVIS_TAG) -s -w" -o release/$(cmd)-windows-amd64 $(exe)
 
 
 
@@ -52,7 +55,7 @@ release:
 	$(MAKE) clean
 	$(MAKE) build
 
-build: release/goss-linux-386 release/goss-linux-amd64 release/goss-linux-arm
+build: release/goss-linux-386 release/goss-linux-amd64 release/goss-linux-arm release/goss-windows-amd64
 
 # TODO(stefan): wheezy URLs are inaccessible and other linuxes are still using dnstest.io that is down. Consider reenabling them.
 # test-int: centos7 wheezy precise alpine3 arch


### PR DESCRIPTION
I've created a personal access token for improbable-eng/goss releases. This PAT is readable by travis and has access only to public repos. The same method is used by https://github.com/aelsabbahy/goss/blob/master/.travis.yml#L23 . I've followed https://www.victorhurdugaci.com/github-releases-travis guide to generate that token.

Testing strategy: check that travis CI is still not broken on linux.  Windows is expectedly broken so far.