### PR TITLE
Patch opencontainers/runc to address CVE-2019-16884

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,20 +1,28 @@
 module github.com/aelsabbahy/goss
 
+go 1.15
+
 require (
 	github.com/achanda/go-sysctl v0.0.0-20160222034550-6be7678c45d2
 	github.com/aelsabbahy/GOnetstat v0.0.0-20160428114218-edf89f784e08
 	github.com/aelsabbahy/go-ps v0.0.0-20170721000941-443386855ca1
 	github.com/cheekybits/genny v0.0.0-20160824153601-e8e29e67948b
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/docker v0.0.0-20161109014415-383a2f046b16
 	github.com/fatih/color v0.0.0-20161025120501-bf82308e8c85
-	github.com/mattn/go-colorable v0.0.9
-	github.com/mattn/go-isatty v0.0.4
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/mattn/go-colorable v0.0.9 // indirect
+	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/miekg/dns v0.0.0-20161018060808-58f52c57ce9d
 	github.com/oleiade/reflections v0.0.0-20160817071559-0e86b3c98b2f
-	github.com/onsi/gomega v0.0.0-20161031154339-ff4bc6b6f9f5
-	github.com/opencontainers/runc v0.0.0-20161107232042-8779fa57eb4a
+	github.com/onsi/ginkgo v1.14.2 // indirect
+	github.com/onsi/gomega v1.10.1
+	github.com/opencontainers/runc v1.0.0-rc9
 	github.com/patrickmn/go-cache v2.0.0+incompatible
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.2.2 // indirect
 	github.com/urfave/cli v0.0.0-20161102131801-d86a009f5e13
-	golang.org/x/sys v0.0.0-20181210030007-2a47403f2ae5
-	gopkg.in/yaml.v2 v2.0.0-20160928153709-a5b47d31c556
+	golang.org/x/sys v0.0.0-20200916030750-2334cc1a136f
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v2 v2.3.0
 )


### PR DESCRIPTION
runc through 1.0.0-rc8, as used in Docker through 19.03.2-ce and other products, allows AppArmor restriction bypass because libcontainer/rootfs_linux.go incorrectly checks mount targets, and thus a malicious Docker image can mount over a /proc directory.

https://www.whitesourcesoftware.com/vulnerability-database/CVE-2019-16884

This upgrades opencontainers/runc to v1.0.0-rc9 with the following commands:
```
go get github.com/opencontainers/runc@v1.0.0-rc9#
go mod tidy
```

No other changes.